### PR TITLE
Remove active plugin message from Settings component

### DIFF
--- a/plugins/multipleplaylists/src/Settings.tsx
+++ b/plugins/multipleplaylists/src/Settings.tsx
@@ -6,7 +6,6 @@ export const Settings = () => {
 	return (
 		<LunaSettings>
 			<div style={{ padding: "16px", textAlign: "center", opacity: 0.7 }}>
-				Multiple Playlists plugin is active. Right-click any song to add it to multiple playlists.
 			</div>
 		</LunaSettings>
 	);


### PR DESCRIPTION
Removed the message about the Multiple Playlists plugin being active.